### PR TITLE
Add editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig help us maintain consistent coding style between different editors.
+#
+# EditorConfig
+# http://editorconfig.org
+#
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION

O `.editorconfig` é para garantir integridade dos fontes (espaçamento, charset, etc) independente do editor.
Tem um plugin para PHPStorm no site. Veja se tu já tem ele instalado.

http://editorconfig.org/
